### PR TITLE
Fix link for Six Pack Extended (6PExt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This list is licensed under [CC0](https://creativecommons.org/publicdomain/zero/
 
 - [VM/370 Downloads - Multiple Versions](http://www.smrcc.org.uk/members/g4ugm/VM370.htm) - This site includes Robert O'Hara's Six Pack Version 1.2, Paul Gorinskey's 5-Pack System, Andy Norrie's 4-Pack system, and Bob Abele's Original 3-Pack System.
 - [Six Pack, Version 1.3 Beta](http://www.smrcc.org.uk/members/g4ugm/SixPack-1.3.Beta.htm)
-- [Six Pack Extended (6PExt)](https://geronimo370.nl/vm6pext/vm-370/)-René Farland's unofficial update to the original Six Pack Version 1.2 Distribution. 6PExt includes the recent RSCS nucleus of Peter Coghlan for NJE support.
+- [Six Pack Extended (6PExt)](https://web.archive.org/web/20231209173332/https://geronimo370.nl/vm6pext/vm-370/)-René Farland's unofficial update to the original Six Pack Version 1.2 Distribution. 6PExt includes the recent RSCS nucleus of Peter Coghlan for NJE support.
 
 #### VM/370 Videos
 


### PR DESCRIPTION
Updated the link for Six Pack Extended (6PExt) to the archived version.